### PR TITLE
chore(build): tag arm version in prebuild binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "install": "node-gyp-build",
-    "prebuild": "prebuildify --napi --tag-libc --strip",
+    "prebuild": "prebuildify --napi --tag-libc --tag-armv --strip",
     "lint": "eslint .",
     "test": "ava && tsd"
   },


### PR DESCRIPTION
This will let us ship prebuild binaries for different arm version (v6, v7, etc.)