### PR TITLE
chore(deps-dev): bump eslint-plugin-promise from 4.3.1 to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-ava": "^12.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-promise": "^5.2",
     "node-gyp": "^8.4.1",
     "prebuildify": "^4.1.1",
     "sharp": "^0.28.0",


### PR DESCRIPTION
Partial upgrade to stay compatible with Node.js 10