### PR TITLE
chore!: drop support for Node.js 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os:
           - macos-latest
           - ubuntu-latest
@@ -50,7 +50,6 @@ jobs:
       - run: npm test
       - name: Run tests for ESM
         run: npm run test:esm
-        if: matrix.node-version != '10.x'
 
   eslint:
     needs: pre_job

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Native module for zopflipng",
   "repository": "realityking/node-zopflipng",
   "engines": {
-    "node": ">=10.13.0"
+    "node": "^14.15.0 || ^16.13.0 || >=18.0.0"
   },
   "keywords": [
     "png",


### PR DESCRIPTION
Breaking change: Require Node@^14.15.0 || ^16.13.0 || >=18.0.0